### PR TITLE
Use a barrier to make sure all threads have been created.

### DIFF
--- a/src/pool.cpp
+++ b/src/pool.cpp
@@ -381,7 +381,7 @@ private:
 		boost::shared_ptr<boost::barrier> barrier(new boost::barrier(count + 1) );
 		for ( ; count > 0; --count )
 		{ // create and detach thread
-			boost::thread t(&impl::worker_thread, this);
+			boost::thread t(&impl::worker_thread, this, barrier);
 		}
 		barrier->wait();
 	}


### PR DESCRIPTION
When using the pool for short-lived operations (i.e. to parallelize
some work and then throwing away the pool), it gets stuck at .stop()

This happens when the pool is stopped before all the threads have
called 'on_thread_start'.

request_stop(pool_size()) does not post an empty task to all threads
(those that are still 'coming to life' don't count in pool_size() yet).

We now use a barrier as a quick fix to make sure all threads are properly 
initialized before start_threads exits.
The test 'queue_until_pool_size' now works reliably.
